### PR TITLE
docs: add README with setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Núcleo de Inovação Tecnológica (NIT)
+
+Este repositório contém o código-fonte do site do Núcleo de Inovação Tecnológica da Unichristus.
+
+## Dependências
+
+- [Git](https://git-scm.com/) para clonar o projeto
+- Navegador moderno com suporte a ES6
+- [Python 3](https://www.python.org/) (opcional) para executar um servidor local
+
+## Como visualizar o site localmente
+
+1. Clone o repositório:
+   ```bash
+   git clone https://github.com/Unichristus/Unichristus-NIT.git
+   cd Unichristus-NIT
+   ```
+2. Abra o arquivo `index.html` diretamente no navegador **ou** inicie um servidor local:
+   ```bash
+   python -m http.server 8000
+   ```
+3. Acesse `http://localhost:8000` no navegador.
+
+## Contribuição
+
+1. Faça um fork deste repositório e clone o fork.
+2. Crie uma branch para sua funcionalidade ou correção:
+   ```bash
+   git checkout -b minha-feature
+   ```
+3. Faça commits com mensagens claras e envie suas alterações:
+   ```bash
+   git commit -m "feat: minha nova feature"
+   git push origin minha-feature
+   ```
+4. Abra um Pull Request descrevendo suas modificações.
+
+## Requisitos mínimos de navegador
+
+O site utiliza recursos do ECMAScript 6. Recomenda-se usar:
+
+- Chrome 60+
+- Firefox 60+
+- Edge 79+
+- Safari 12+
+


### PR DESCRIPTION
## Summary
- document dependencies and local site preview steps
- add contribution guidelines and browser requirements

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b88c689c78832e8c899762cab5fc06